### PR TITLE
Fixes the find_tool() function so it looks in other paths

### DIFF
--- a/adept.sh
+++ b/adept.sh
@@ -164,7 +164,7 @@ function find_tool () {
     # Array of possible tool locations: name, name as ALL-CAPS, /usr/bin/name, /usr/local/bin/name and custom path
 	local __possibletoollocations=(${__tool} ${__tool^^} /usr/bin/${__tool} /usr/local/bin/${__tool} ${__customtoolpath})
 	# For each possible tool location, test if its actually available there
-	for i in "${__possibletoollocations}"; do
+	for i in "${__possibletoollocations[@]}"; do
 		local __commandlinetool=$(type -p $i)
 		# If 'type -p' returned something, we now have our proper handle
 		if [ "$__commandlinetool" ]; then

--- a/unittests/tests_adept.bats
+++ b/unittests/tests_adept.bats
@@ -7,6 +7,12 @@ source "${BATS_TEST_DIRNAME}/../adept.sh" >/dev/null 2>/dev/null
   [ $status -eq 0 ]
 }
 
+# Make sure that we actually look for tools in other directories than $PATH
+@test "Find Tools with path resolving" {
+  run find_tool IDENTIFY_COMMAND nonexistingcommand identify
+  [ $status -eq 0 ]
+}
+
 @test "Validate Input JPEG" {
   validate_image VALIDJPEG "test.jpg"
   result=${VALIDJPEG}


### PR DESCRIPTION
The for-loop only checks the first element in the array and will not attempt to locate tools in any of the other paths. This causes it to fail if the tool does not exist in $PATH.
